### PR TITLE
Update content of SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,7 @@
 # Security and Responsible Disclosure Policy
 
+The Centers for Medicare & Medicaid Services is committed to ensuring the security of the American public by protecting their information from unwarranted disclosure. We want security researchers to feel comfortable reporting vulnerabilities they have discovered so we can fix them and keep our users safe. We developed our disclosure policy to reflect our values and uphold our sense of responsibility to security researchers who share their expertise with us in good faith.
+
 *Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
 email or via GitHub Issues. Please use our website to submit vulnerabilities at
 [https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).


### PR DESCRIPTION
## Update content of SECURITY.md

## Problem

Based on previous discussion in #17, we decided to keep SECURITY.md as part of our repository documentation and reduce content in the README.md Security Policy section.

## Solution

SECURITY.md now includes a description regarding the purpose and goals of CMS's disclosure policies. This description was taken from the README.md