### PR TITLE
Updated README to add missing files to Documentation Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ An up-to-date list of core team members can be found in [MAINTAINERS.md](MAINTAI
 - [MAINTAINERS.md](./MAINTAINERS.md)
 - [CODEOWNERS.md](./CODEOWNERS.md)
 - [GOVERNANCE.md](./GOVERNANCE.md)
+- [COMMUNITY_GUIDELINES.md](./COMMUNITY_GUIDELINES.md)
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
 - [SECURITY.md](./SECURITY.md)
 - [LICENSE](./LICENSE)
 
@@ -121,7 +123,7 @@ Thank you for considering contributing to an Open Source project of the US Gover
 Those responsible for the code and documentation in this repository can be found in [CODEOWNERS.md](CODEOWNERS.md).
 
 ## Community
-The eCQM Dedupe team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
+The DeDupliFHIR team is taking a community-first and open source approach to the product development of this tool. We believe government software should be made in the open and be built and licensed such that anyone can download the code, run it themselves without paying money to third parties or using proprietary software, and use it as they will.
 
 We know that we can learn from a wide variety of communities, including those who will use or will be impacted by the tool, who are experts in technology, or who have experience with similar technologies deployed in other spaces. We are dedicated to creating forums for continuous conversation and feedback to help shape the design and development of the tool.
 


### PR DESCRIPTION
## Updated README to add missing files to Documentation Index

## Problem

The Documentation Index section were missing some markdown files.

## Solution

Added `COMMUNITY_GUIDELINES.md` and `CODE_OF_CONDUCT.md`to Documentation Index section. Also updated team name in community section to match team name in `COMMUNITY_GUIDELINES.md`.
