### PR TITLE
Add Command to Generate Diff Files and Print Their Paths

### DIFF
--- a/cli/ecqm_dedupe.py
+++ b/cli/ecqm_dedupe.py
@@ -73,7 +73,7 @@ def gen_diff(html,output_path,processed_patient_data_path):
     #Get text from csv with dupes
     cache_df = pd.read_csv(processed_patient_data_path + "dedupe-cache.csv")
 
-    #Get a dataframe with all of the paths concatinated attached to their cluster id.
+    #Get a dataframe with all of the paths concatenated attached to their cluster id.
     grouped_dirs = cache_df.groupby('cluster_id')['path'].apply(' '.join).reset_index()
     
     #convert to list

--- a/cli/ecqm_dedupe.py
+++ b/cli/ecqm_dedupe.py
@@ -130,7 +130,8 @@ def gen_html_diff(pathOne, pathTwo):
 @click.command()
 def clear_cache():
     """Clear cache of dedupliFHIED patient data"""
-    shutil.rmtree(CACHE_DIR)
+    os.remove(CACHE_DIR + "unique-records-cache.csv")
+    os.remove(CACHE_DIR + "dedupe-cache.csv")
     print("Cache cleared.")
 
 @click.command()


### PR DESCRIPTION

## Add Command to Generate Diff Files and Print Their Paths

## Problem

As part of our Alpha process, we have planned to add a CLI command to generate diff comparisons between the detected duplicate patient data files.

## Solution

Create the CLI command `gen-diff` to generate diff files for the previously computed duplicates. 

## Result

A new command has been added called `gen-diff` that generates diff files in the cache directory as well as printing out any files that point to the same patient on the same line in a text output to stdout. For example:
```
file1 file2
file5 file8 file9 file12
```
This would show that `file1` and `file2` point to the same person and need to have someone look over them and merge them. Same with `file5` `file9` and `file12` all being duplicate files for the same person. This way the standard out can be easily be used to highlight work for the user to do in the front end. 

Diff files are only generated for duplicates that have only two duplicate records currently.

## Important Notes For Reviewers

It is important to note that diffs can only be generated to compare two files so if many files are deemed to be duplicates some other method needs to be used to compare them such as [diffuse](https://diffuse.sourceforge.net/). This is something that we should talk about next time we have the chance to talk front end strategy since there are many routes we could go.


