### PR TITLE
Removed unnecessary inline styling from alerts

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -27,6 +27,10 @@ h2,
   width: 100%;
 }
 
+.usa-alert {
+  display: none;
+}
+
 .loader {
   position: absolute;
   left: 42.5%;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,7 +28,7 @@
             accept=".json,.csv"
           />
         </div>
-        <div class="usa-alert usa-alert--error" id="file-input-alert" role="alert" style="display: none;">
+        <div class="usa-alert usa-alert--error" id="file-input-alert" role="alert" style="">
           <div class="usa-alert__body">
             <h4 class="usa-alert__heading">Error</h4>
             <p class="usa-alert__text">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,7 +28,7 @@
             accept=".json,.csv"
           />
         </div>
-        <div class="usa-alert usa-alert--error" id="file-input-alert" role="alert" style="">
+        <div class="usa-alert usa-alert--error" id="file-input-alert" role="alert">
           <div class="usa-alert__body">
             <h4 class="usa-alert__heading">Error</h4>
             <p class="usa-alert__text">

--- a/frontend/pages/success.html
+++ b/frontend/pages/success.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
     <link rel="stylesheet" href="../node_modules/@uswds/uswds/dist/css/uswds.min.css">
     <link rel="stylesheet" href="../css/style.css">
     <title>DedupliFHIR</title>
@@ -38,7 +38,7 @@
           </tr>
         </tbody>
       </table> -->
-      <div class="usa-alert usa-alert--success" id="download-success-alert" role="alert" style="display: none;">
+      <div class="usa-alert usa-alert--success" id="download-success-alert" role="alert">
         <div class="usa-alert__body">
           <h4 class="usa-alert__heading">Success</h4>
           <p class="usa-alert__text">
@@ -46,7 +46,7 @@
           </p>
         </div>
       </div>
-      <div class="usa-alert usa-alert--error" id="download-fail-alert" role="alert" style="display: none;">
+      <div class="usa-alert usa-alert--error" id="download-fail-alert" role="alert">
         <div class="usa-alert__body">
           <h4 class="usa-alert__heading">Error</h4>
           <p class="usa-alert__text">


### PR DESCRIPTION
## Removed unnecessary inline styling from alerts

## Problem

After reviewing each HTML page, I decided to remove inline styling from alerts to abide by Security Content Policy best practices.

## Solution

- Remove `display: none` inline styling from alerts and added it to css file instead
- Updated Security Content Policy accordingly by removing `unsafe-inline`