### PR TITLE
Use `__file__` to find test data

### DIFF
--- a/cli/deduplifhirLib/utils.py
+++ b/cli/deduplifhirLib/utils.py
@@ -126,7 +126,10 @@ def use_linker(func):
         print(f"Format is {fmt}")
         print(f"Data dir is {data_dir}")
 
-        training_df = parse_test_data('../cli/deduplifhirLib/test_data.csv',marked=True)
+        dir_path = os.path.dirname(os.path.realpath(__file__))
+
+        training_df = parse_test_data(dir_path + '/test_data.csv',marked=True)
+
         if fmt == "FHIR":
             train_frame = pd.concat([parse_fhir_data(data_dir),training_df])
         elif fmt == "QRDA":


### PR DESCRIPTION
## Use `__file__` to find test data

## Problem

Right now the script throws an error on dev where it can't find the test data.

## Solution

Get the file path relative to the script file path using the `__file__` keyword.
