### PR TITLE
Check Inputs for Presence of Unique Blocking Values

### DIFF
--- a/cli/deduplifhirLib/utils.py
+++ b/cli/deduplifhirLib/utils.py
@@ -21,6 +21,11 @@ from deduplifhirLib.settings import SPLINK_LINKER_SETTINGS_PATIENT_DEDUPE, read_
 base_dir = os.path.abspath(os.path.dirname(__file__))
 
 
+def check_blocking_uniques(check_df,blocking_field,required_uniques=5):
+    uniques = getattr(check_df, blocking_field).nunique(dropna=True)
+    assert uniques >= required_uniques
+
+
 def parse_qrda_data(path,cpu_cores=4):
     raise NotImplementedError
 

--- a/cli/deduplifhirLib/utils.py
+++ b/cli/deduplifhirLib/utils.py
@@ -22,6 +22,15 @@ base_dir = os.path.abspath(os.path.dirname(__file__))
 
 
 def check_blocking_uniques(check_df,blocking_field,required_uniques=5):
+    """
+    Function that takes in a dataframe and asserts the required blocking values
+    are present for splink to use. Throws an assertion error if it can't.
+
+    Arguments:
+        check_df: Pandas Dataframe to check
+        blocking_field: Column of the frame to check uniques of
+        required_uniques: Unique values to require for blocking rules
+    """
     uniques = getattr(check_df, blocking_field).nunique(dropna=True)
     assert uniques >= required_uniques
 
@@ -147,6 +156,17 @@ def use_linker(func):
         elif fmt == "TEST":
             train_frame = training_df
 
+        #check blocking values
+        for rule in SPLINK_LINKER_SETTINGS_PATIENT_DEDUPE['blocking_rules_to_generate_predictions']:
+            try:
+                if isinstance(rule, list):
+                    for sub_rule in rule:
+                        check_blocking_uniques(train_frame, sub_rule)
+                else:
+                    check_blocking_uniques(train_frame, rule)
+            except AssertionError as e:
+                print(f"Could not assert the proper number of unique records for rule {rule}")
+                raise e
 
         lnkr = DuckDBLinker(train_frame, SPLINK_LINKER_SETTINGS_PATIENT_DEDUPE)
         lnkr.estimate_u_using_random_sampling(max_pairs=5e6)


### PR DESCRIPTION
## Check Inputs for Presence of Unique Blocking Values

## Problem

Certain inputs are causing complex errors. Further info can be found on the relevant issue page for #58 

## Solution

Check the inputs for proper contents. In this case it was the lack of SSNs present in the data. 

## Result

I have added a pre-parse step to the dedupliFHIR CLI that throws an assertion error if there are less than 5 unique values for any of the blocking rules. The proper user response to this error is to tweak the blocking rules defined in the settings file. 

## Test Plan

Test on the given data as well as testing blank values for the other default blocking columns. 
