### PR TITLE
Fix Bug with Bad Settings Parse

### DIFF
--- a/cli/deduplifhirLib/settings.py
+++ b/cli/deduplifhirLib/settings.py
@@ -38,6 +38,7 @@ SPLINK_LINKER_SETTINGS_PATIENT_DEDUPE.update({
 
 #apply blocking function to translate into sql rules
 blocking_rules = SPLINK_LINKER_SETTINGS_PATIENT_DEDUPE["blocking_rules_to_generate_predictions"]
+BLOCKING_RULE_STRINGS = blocking_rules
 SPLINK_LINKER_SETTINGS_PATIENT_DEDUPE["blocking_rules_to_generate_predictions"] = list(map(block_on,blocking_rules))
 
 

--- a/cli/deduplifhirLib/utils.py
+++ b/cli/deduplifhirLib/utils.py
@@ -15,7 +15,9 @@ from functools import wraps
 import pandas as pd
 from splink.duckdb.linker import DuckDBLinker
 
-from deduplifhirLib.settings import SPLINK_LINKER_SETTINGS_PATIENT_DEDUPE, read_fhir_data
+from deduplifhirLib.settings import (
+    SPLINK_LINKER_SETTINGS_PATIENT_DEDUPE, BLOCKING_RULE_STRINGS, read_fhir_data
+)
 
 
 base_dir = os.path.abspath(os.path.dirname(__file__))
@@ -159,7 +161,7 @@ def use_linker(func):
             raise ValueError('Unrecognized format to parse')
 
         #check blocking values
-        for rule in SPLINK_LINKER_SETTINGS_PATIENT_DEDUPE['blocking_rules_to_generate_predictions']:
+        for rule in BLOCKING_RULE_STRINGS:
             try:
                 if isinstance(rule, list):
                     for sub_rule in rule:


### PR DESCRIPTION
## Fix Bug with Bad Settings Parse

## Problem

For whatever reason I ran into a bug parsing the settings that I didn't when I first merged these changes into dev. 

## Solution

Create a new object of the blocking rule strings as a constant for the application to use. 
