### PR TITLE
add dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## add dependabot.yml 

## Problem

Dependabot doesn't currently automatically file PRs on this repository. 

## Solution

Enable dependabot through the dependabot.yml file. 
