### PR TITLE
Patch Address Parsing and Print Comparison 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11","3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry

--- a/cli/deduplifhirLib/splink_settings.json
+++ b/cli/deduplifhirLib/splink_settings.json
@@ -3,7 +3,6 @@
     "blocking_rules_to_generate_predictions": [
          "birth_date",
         ["ssn", "birth_date"],
-        ["ssn", "street_address0"],
         "phone"
     ],
     "max_iterations": 20,


### PR DESCRIPTION
## Patch Address Parsing and Print Comparison 

## Problems

- We weren't sorting addresses alphabetically for FHIR data ( CSV data has user-defined order so we don't want to sort it)
- Bug in how we were parsing CSVs where we ignored the `normal_row` variable and used the wrong variable instead
- Missing calculations of number of impending comparisons on your CPU 
- We were adding term frequency adjustments to address data which doesn't make sense


## Solution


- Add `sorted` builtin function to sort all parsed FHIR addresses
- Use `normal_row` variable where intended
- Add calculation of how many comparisons will be generated for each requested blocking rule in the data and print that data to stdout
- Remove term frequency adjustments from address data


## Test Plan

`make test`