### PR TITLE
Add Workflow to Auto-generate CHANGELOG.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,15 @@ on:
     types: [published]
 
 jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "✏️ Generate release changelog"
+        uses: heinrichreimer/action-github-changelog-generator@v2.3
+        with:
+          base: CHANGELOG.md
+          token: ${{ secrets.GITHUB_TOKEN }} 
+
   publish:
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Add Workflow to Auto-generate CHANGELOG.md

## Problem

We currently don't keep releases or a changelog on this project.

## Solution

Auto-generate a changelog and start to use tags on this repository.

## Result

A changelog will generate whenever a release is published based on the tags on this project.
