### PR TITLE
Frontend: Minor UI Fixes

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -27,6 +27,11 @@ h2,
   width: 100%;
 }
 
+#submit {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
 .usa-button-group {
   justify-content: center;
 }

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -70,7 +70,8 @@ img {
   animation: spin 2s linear infinite;
 }
 
-ul, ol {
+ul,
+ol {
   padding-left: 15px;
 }
 

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -70,9 +70,12 @@ img {
   animation: spin 2s linear infinite;
 }
 
-.security-info {
-  padding-inline-start: 0;
-  list-style-position: inside;
+ul, ol {
+  padding-left: 15px;
+}
+
+ol {
+  margin-bottom: 0px;
 }
 
 @keyframes spin {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -27,7 +27,7 @@
           />
         </div>
         <div class="usa-form-group">
-        <label class="usa-label" for="options">Select file format for results data</label>
+        <label class="usa-label" for="options">Select file format for your results data</label>
         <select class="usa-select" name="options" id="options">
           <option value=".xlsx" selected="selected" >.xlsx</option>
           <option value=".csv">.csv</option>

--- a/frontend/pages/success.html
+++ b/frontend/pages/success.html
@@ -32,8 +32,9 @@
           <b>To find possible duplicates:</b>
           <ol>
             <li>Open your results file.</li>
-            <li>Find the records with the same <b>cluster_id</b>.<br><a href="https://github.com/DSACMS/dedupliFHIR/blob/main/research/sept-2024/examples-use-clusterid-to-find-possible-duplicates.md" target="_blank">(See examples.)</a></li>
+            <li>Find the records with the same <b>cluster_id</b>.</li>
           </ol>
+          <a href="https://github.com/DSACMS/dedupliFHIR/blob/main/research/sept-2024/examples-use-clusterid-to-find-possible-duplicates.md" target="_blank">(See examples.)</a>
         </p>
       </div> 
       <button type="button" class="usa-button" id="save-file">Save the results file</button>

--- a/frontend/pages/success.html
+++ b/frontend/pages/success.html
@@ -30,6 +30,7 @@
       <div class="results-spreadsheet-instructions" id="results-spreadsheet-instructions">
         <p>
           <b>To find possible duplicates:</b>
+          <ol>
             <li>Open your results file.</li>
             <li>Find the records with the same <b>cluster_id</b>.<br><a href="https://github.com/DSACMS/dedupliFHIR/blob/main/research/sept-2024/examples-use-clusterid-to-find-possible-duplicates.md" target="_blank">(See examples.)</a></li>
           </ol>


### PR DESCRIPTION
## Frontend: Minor UI Fixes

## Problem

Made a couple of minor UI fixes based on Meg's feedback on #131 
https://github.com/DSACMS/dedupliFHIR/pull/131#issuecomment-2358904019

## Solution
- In `index.html`, 2nd line wraps right under the first bullet point
- In `success.html`, changed to a numbered list & "See examples" wraps under number 2.

## Result

index.html:
<img width="902" alt="Screenshot 2024-09-18 at 12 25 50 PM" src="https://github.com/user-attachments/assets/09aeea94-2edc-415f-bf8e-366540f4cc6d">

success.html:
<img width="902" alt="Screenshot 2024-09-18 at 12 25 35 PM" src="https://github.com/user-attachments/assets/63ad77fc-6522-496f-b9d3-86ff0fcb4db1">

## Test Plan
`npm test` to run frontend tests