### PR TITLE
fixed windows build by changing path

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -14,15 +14,25 @@ var resultsFile;
 
 function findPython() {
   const possibilities = [
-    // In packaged app
+    // In packaged app (mac / linux)
     path.join(process.resourcesPath, "python", "bin", "python"),
     path.join(process.resourcesPath, "python", "bin", "python3"),
     path.join(process.resourcesPath, "python", "bin", "python3.10"),
     path.join(process.resourcesPath, "python", "bin", "python3.11"),
     path.join(process.resourcesPath, "python", "bin", "python3.12"),
 
-    // In development
+    // In development (mac / linux)
     path.join("..", ".venv", "bin", "python"),
+
+    // In packaged app (windows)
+    path.join(process.resourcesPath, "python", "Scripts", "python.exe"),
+    path.join(process.resourcesPath, "python", "Scripts", "python3.exe"),
+    path.join(process.resourcesPath, "python", "Scripts", "python3.10.exe"),
+    path.join(process.resourcesPath, "python", "Scripts", "python3.11.exe"),
+    path.join(process.resourcesPath, "python", "Scripts", "python3.12.exe"),
+    
+    // In development (windows)
+    path.join("..", ".venv", "Scripts", "python.exe"),
   ];
   for (const path of possibilities) {
     if (fs.existsSync(path)) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on
these changes.

Help us understand your motivation by explaining why you decided to make this change.

Happy contributing!

- Comments should be formatted to a width no greater than 80 columns.

- Files should be exempt of trailing spaces.

- We adhere to a specific format for commit messages. Please write your commit
messages along these guidelines. Please keep the line width no greater than 80
columns (You can use `fmt -n -p -w 80` to accomplish this).


-->

## frontend: fixed windows build by changing path

## Problem

not running on windows properly

## Solution

included the windows specific path name which was separate from mac/linux

## Result

can now run on windows 

## Test Plan

ran program with other developers
make test
